### PR TITLE
Fix a syntax error

### DIFF
--- a/gtk-3.20/gtk-widgets.css
+++ b/gtk-3.20/gtk-widgets.css
@@ -1607,7 +1607,7 @@ scale {
     min-height: 10px;
     min-width: 10px;
     padding: 12px; 
-    background-colo: transparent;
+    background-color: transparent;
 }
 
 scale slider {


### PR DESCRIPTION
This error will cause a GTK warning: Theme parsing error: gtk-widgets.css:1610:19: 'background-colo' is not a valid property name.
=> Correct property name to 'background-color'.