### PR TITLE
Update cinnamon.css

### DIFF
--- a/cinnamon/cinnamon.css
+++ b/cinnamon/cinnamon.css
@@ -1999,6 +1999,8 @@ StScrollBar StButton#hhandle:focus {
 
 .applet-icon {
   icon-size: 12px;
+  padding-left: 6px;
+  padding-right: 6px;
 }
 
 .applet-icon:hover,


### PR DESCRIPTION
Fixed Padding for Applet Icons. Lines 2002 and 2003 added.  I will post Screenshot of the effect in a few seconds within this comment. Screenshot is from weather Applet Cinnamon Spices weather@mockturtl.
Before:
![before](https://user-images.githubusercontent.com/60874062/94714343-4f6eee80-034c-11eb-861c-1d5698669ccc.png)
After:
![after](https://user-images.githubusercontent.com/60874062/94714342-4ed65800-034c-11eb-871a-85a6cb3d812d.png)

Kind regards
Michael