### PR TITLE
Update cinnamon.css, adding applet icon padding

### DIFF
--- a/cinnamon/cinnamon.css
+++ b/cinnamon/cinnamon.css
@@ -1999,6 +1999,8 @@ StScrollBar StButton#hhandle:focus {
 
 .applet-icon {
   icon-size: 12px;
+  padding left: 3px;
+  padding right: 3px;
 }
 
 .applet-icon:hover,


### PR DESCRIPTION
Added left and right padding as suggested by @Elbullazul and also created it as new PR.
Lines 2002 - 2003
padding left: 3px
padding right: 3px