### PR TITLE
feat: add color-scheme to index.theme

### DIFF
--- a/index.theme
+++ b/index.theme
@@ -6,6 +6,7 @@ Encoding=UTF-8
 
 [X-GNOME-Metatheme]
 GtkTheme=Windows-10-Dark
+GtkColorScheme=prefer-dark
 MetacityTheme=Windows-10-Dark
 IconTheme=Windows-10-Icons
 CursorTheme=DMZ-White


### PR DESCRIPTION
lets browsers display websites in dark (via CSS prefers-color-scheme) when the dark theme is active