### PR TITLE
Fix issue #43

### DIFF
--- a/cinnamon/cinnamon.css
+++ b/cinnamon/cinnamon.css
@@ -1623,7 +1623,7 @@ StScrollBar StButton#hhandle:focus {
   caret-color: black;
   caret-size: 1px;
   width: 400px;
-  height: 15px;
+  height: auto;
 }
 
 #menu-search-entry:focus,


### PR DESCRIPTION
Fix the text issue with the search bar. The height was a fixed 15px which caused it to cut off the text when typing. Setting it to auto fixes it.